### PR TITLE
Grammar fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ patches and features.
 ## Using the issue tracker
 
 The issue tracker is the preferred channel for [bug reports](#bugs),
-[features requests](#features) and [submitting pull
+[feature requests](#features) and [submitting pull
 requests](#pull-requests), but please respect the following restrictions:
 
 * Please **do not** use the issue tracker for personal support requests (use
@@ -59,11 +59,11 @@ provide as much detail and context as possible.
 <a name="pull-requests"></a>
 ## Pull requests
 
-Contributing to libgdx is easy:
+Contributing to libGDX is easy:
 
-  * Fork libgdx on http://github.com/libgdx/libgdx
+  * Fork libGDX on [`http://github.com/libgdx/libgdx`](http://github.com/libgdx/libgdx)
   * Learn how to [Work with the Source](https://github.com/libgdx/libgdx/wiki/Running-demos-%26-tests)
-  * Hack away and sent a pull request on Github!
+  * Hack away, and send a pull request on GitHub!
 
 ### API Changes & Additions
 If you modify a public API, or add a new one, make sure to add these changes to the [CHANGES](https://github.com/libgdx/libgdx/blob/master/CHANGES) file in the root of the repository. In addition to the CHANGES file, such modifications are also published on the [blog](http://www.badlogicgames.com) and on [Twitter](http://www.twitter.com/badlogicgames) to reach all of the community.
@@ -72,22 +72,21 @@ If you want to poll the brains of other devs, either send a pull request and sta
 
 ### Contributor License Agreement
 
-Libgdx is licensed under the [Apache 2.0 license](http://en.wikipedia.org/wiki/Apache_License). Before we can accept code contributions, we need you to sign our [contributor license agreement](https://github.com/libgdx/libgdx/blob/master/CLA.txt). Just print it out, fill in the blanks and send a copy to contact@badlogicgames.com, with the subject `[Libgdx] CLA`.
+Libgdx is licensed under the [Apache 2.0 license](http://en.wikipedia.org/wiki/Apache_License). Before we can accept code contributions, we need you to sign our [contributor license agreement](https://github.com/libgdx/libgdx/blob/master/CLA.txt). Just print it out, fill in the blanks and send a copy to [`contact@badlogicgames.com`](mailto:contact@badlogicgames.com?subject=[LibGDX]%20CLA), with the subject `[Libgdx] CLA`.
 
 Signing the CLA will allow us to use and distribute your code. This is a non-exclusive license, so you retain all rights to your code. It's a fail-safe for us should someone contribute essential code and later decide to take it back.
 
 ### Eclipse Formatter
 
-If you work on libgdx code, we require you to use the [Eclipse formatter](https://github.com/libgdx/libgdx/blob/master/eclipse-formatter.xml) located in the root directory of the repository.
+If you work on libGDX code, we require you to use the [Eclipse formatter](https://github.com/libgdx/libgdx/blob/master/eclipse-formatter.xml) located in the root directory of the repository.
 
 Failure to use the formatter will result in Nate being very upset.
 
-If you are using IntelliJ IDEA, you can still make use of the eclipse code formatter:
-see: [this article](http://blog.jetbrains.com/idea/2014/01/intellij-idea-13-importing-code-formatter-settings-from-eclipse/?utm_source=hootsuite&utm_campaign=hootsuite)
+If you are using IntelliJ IDEA, you can still make use of the eclipse code formatter. See [this article](http://blog.jetbrains.com/idea/2014/01/intellij-idea-13-importing-code-formatter-settings-from-eclipse/?utm_source=hootsuite&utm_campaign=hootsuite) for more information.
 
 ### Code Style
 
-Libgdx does not have an official coding standard. We mostly follow the usual [Java style](http://www.oracle.com/technetwork/java/codeconvtoc-136057.html), and so should you.
+LibGDX does not have an official coding standard. We mostly follow the usual [Java style](http://www.oracle.com/technetwork/java/codeconvtoc-136057.html), and so should you.
 
 A few things we'd rather not like to see:
 
@@ -107,22 +106,22 @@ If your class is explicitly thread-safe, mention it in the Javadoc. The default 
 
 ### Performance Considerations
 
-Libgdx is meant to run on both desktop and mobile platforms, including browsers (JavaScript!). While the desktop HotSpot VM can take quite a beating in terms of unnecessary allocations, Dalvik and consorts don't.
+LibGDX is meant to run on both desktop and mobile platforms, including browsers (JavaScript!). While the desktop HotSpot VM can take quite a beating in terms of unnecessary allocations, Dalvik and consorts don't.
 
 A couple of guidelines:
 
   * Avoid temporary object allocation wherever possible
   * Do not make defensive copies
-  * Avoid locking, libgdx classes are by default not thread-safe unless explicitly specified
+  * Avoid locking. libGDX classes are, by default, not thread-safe unless explicitly specified
   * Do not use boxed primitives
-  * Use the collection classes in the [com.badlogic.gdx.utils package](https://github.com/libgdx/libgdx/tree/master/gdx/src/com/badlogic/gdx/utils)
+  * Use the collection classes in the [`com.badlogic.gdx.utils` package](https://github.com/libgdx/libgdx/tree/master/gdx/src/com/badlogic/gdx/utils)
   * Do not perform argument checks for methods that may be called thousands of times per frame
   * Use pooling if necessary, if possible, avoid exposing the pooling to the user as it complicates the API
 
 ### Git
 
-Most of the libdgx team members are Git novices, as such we are just learning the ropes ourself. To lower the risk of getting something wrong, we'd kindly ask you to keep your pull requests small if possible. A change-set of 3000 files is likely not to get merged.
+Most of the libGDX team members are Git novices. As such, we are just learning the ropes ourselves. To lower the risk of getting something wrong, we'd kindly ask you to keep your pull requests small if possible. A changeset of 3000 files is likely not to get merged.
 
 We do open new branches for bigger API changes. If you help out with a new API, make sure your pull request targets that specific branch.
 
-Pull requests for the master repository will be checked by multiple core contributors before inclusion. We may reject your pull requests to master if we do not deem them to be ready or fitting. Please don't take offense in that case. Libgdx is used by thousands of projects around the world, we need to make sure things stay somewhat sane and stable.
+Pull requests for the master repository will be checked by multiple core contributors before inclusion. We may reject your pull request to `master` if we do not deem them to be ready or fitting. Please don't take offense in that case. LibGDX is used by thousands of projects around the world. We need to make sure things stay somewhat sane and stable.


### PR DESCRIPTION
By section:
# Using the issue tracker

"feature" should be singular
# Pull requests

Capitalize "GDX" in "libGDX" (3 times), capitalize "H" in "GitHub", use "send" instead of "sent", make the URL a link
# CLA

Make the e-mail a `mailto:` link, filling in the subject automatically
# Eclipse formatting

Capitalize "GDX", getting rid of a list with only one item
# Performance considerations

Capitalize "GDX" (x2), format correctly the package name
# Git

Capitalize "GDX", fix ordering of letters in "GDX" and capitalize, fix 2 run-on sentences, use a plural noun for "ourselves", "changeset" is one word, and "request" is used in a singular context.
